### PR TITLE
Implement "costing"

### DIFF
--- a/app/templates/machine.html
+++ b/app/templates/machine.html
@@ -9,6 +9,7 @@
       <th scope="col">User Name</th>
       <th scope="col">Start Time</th>
       <th scope="col">Time Used</th>
+      <th scope="col">Charge</th>
     </tr>
   </thead>
   <tbody>
@@ -18,6 +19,11 @@
       <td scope="row"><a href="{{ url_for('user', user_uid=used_.useruid)}}">{{ used_.user.username }}</td>
       <td>{{ used_.starttime}}</td>
       <td>{{ used_.elapsed }}</td>
+      <td>
+          {% if used_.charge %}
+            {{ "£%.2f"|format(used_.charge)}}
+          {% endif %}
+      </td>
     </tr>
     {% endfor %}
   </tbody>

--- a/app/templates/machine.html
+++ b/app/templates/machine.html
@@ -1,6 +1,23 @@
 {% extends "base.html" %}
 {% block body %}
-<h2>Last usage for {{ machine_details.machinename }}</h2>
+<h2>{{ machine_details.machinename }}</h2>
+<div class="row">
+  <div class="col-sm">
+      <!-- Status doesn't mean anything at the moment... Just a placeholder-->
+      <h6>Current Status</h6>
+      <p>{{ machine_details.status }}</p>
+  </div>
+  <div class="col-sm">
+    <h6>Cost Per Minute</h6>
+    <p>{{ "£%.2f"|format(machine_details.costperminute)}}</p>
+  </div>
+  <div class="col-sm">
+      <h6>Minimum Charge</h6>
+      <p>{{ "£%.2f"|format(machine_details.costminimum)}}</p>
+  </div>
+
+</div>
+<h3>Latest Usage</h3>
 <p>Showing the 25 most recent entries.</p>
 
 <table class="table">

--- a/app/templates/machine.html
+++ b/app/templates/machine.html
@@ -1,5 +1,25 @@
 {% extends "base.html" %}
 {% block body %}
-<h2>Last usage for {{ machine_details.machinename }}</h2><br>
+<h2>Last usage for {{ machine_details.machinename }}</h2>
+<p>Showing the 25 most recent entries.</p>
 
+<table class="table">
+  <thead>
+    <tr>
+      <th scope="col">User Name</th>
+      <th scope="col">Start Time</th>
+      <th scope="col">Time Used</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for used_ in last_usage %}
+    {# Iterate over the last 25 log entries #}
+    <tr>
+      <td scope="row"><a href="{{ url_for('user', user_uid=used_.useruid)}}">{{ used_.user.username }}</td>
+      <td>{{ used_.starttime}}</td>
+      <td>{{ used_.elapsed }}</td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
 {% endblock %}

--- a/app/templates/newmachine.html
+++ b/app/templates/newmachine.html
@@ -26,9 +26,36 @@
     <input class="form-control" type="text" name="machineuid" id="machineuid" value="{{ machine_uid }}" readonly>
   </div>
   <div class="form-group">
-    <label for="machinename">Machine name</label>
+    <label for="machinename">Machine Name</label>
     <input class="form-control" type="text" name="machinename" id="machinename" maxlength="45">
   </div>
+  <div class="row">
+  <div class="col-sm-6">
+       <div class="form-group">
+      <label for="machinename">Cost Per Minute</label>
+      <div class="input-group">
+          <span class="input-group-addon">£</span>
+          <input class="form-control" type="number" name="costperminute" id="costperminute" step="0.01" value="0.0" minimum="0">
+    </div>
+  </div>
+</div>
+  <div class="col-sm-6">
+    <div class="form-group">
+
+      <label for="machinename">Minimum Charge</label>
+
+      <div class="input-group">
+          <span class="input-group-addon">£</span>
+          <input class="form-control" type="number" name="costminimum" id="costminimum" step="0.01" value ="0.0" minimum="0">
+      </div>
+      <p id="minimumChargeHelpBlock" class="form-text text-muted">
+        Leave this field set to 0.0 if there is no minimum charge for this machine. If <em>Cost Per Minute</em> equals 0.0 then this value will be considered a "per use" charge.
+      </p>
+    </div>
+  </div>
+
+</div>
+
   <input type="submit" class="btn btn-primary" value="Create">
 </form>
 

--- a/app/templates/user.html
+++ b/app/templates/user.html
@@ -9,6 +9,7 @@
       <th scope="col">Machine Name</th>
       <th scope="col">Start Time</th>
       <th scope="col">Time Used</th>
+      <th scope="col">Charge</th>
     </tr>
   </thead>
   <tbody>
@@ -18,6 +19,12 @@
       <td scope="row"><a href="{{ url_for('machine', machine_uid=used_.machineuid) }}">{{ used_.machine.machinename }}</th></td>
       <td>{{ used_.starttime}}</td>
       <td>{{ used_.elapsed }}</td>
+      <td>
+          {% if used_.charge %}
+            {{ "£%.2f"|format(used_.charge)}}
+          {% endif %}
+      </td>
+
     </tr>
     {% endfor %}
   </tbody>

--- a/app/templates/user.html
+++ b/app/templates/user.html
@@ -1,5 +1,25 @@
 {% extends "base.html" %}
 {% block body %}
-<h2>Last usage for {{ user_details.username }}</h2><br>
+<h2>Last usage for {{ user_details.username }}</h2>
+<p>Showing the 25 most recent entries.</p>
 
+<table class="table">
+  <thead>
+    <tr>
+      <th scope="col">Machine Name</th>
+      <th scope="col">Start Time</th>
+      <th scope="col">Time Used</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for used_ in last_usage %}
+    {# Iterate over the last 25 log entries #}
+    <tr>
+      <td scope="row"><a href="{{ url_for('machine', machine_uid=used_.machineuid) }}">{{ used_.machine.machinename }}</th></td>
+      <td>{{ used_.starttime}}</td>
+      <td>{{ used_.elapsed }}</td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
 {% endblock %}

--- a/app/views.py
+++ b/app/views.py
@@ -109,7 +109,7 @@ def machine(machine_uid):
         # the best way to do this, suggestions welcome.
         for p in last_usage:
             timediff = p.endtime - p.starttime
-            p.elapsed = format_timedelta(timediff, granularity="second", locale="en_GB")
+            p.elapsed = format_timedelta(timediff, granularity="second", threshold=2, locale="en_GB")
 
         return render_template("machine.html", machine_details=machine_details, last_usage=last_usage)
     except Exception as ex:
@@ -291,7 +291,7 @@ def logusage():
             return "{\"error\":\"Machine UID doesn't exist\"}", 400 # 400 BAD REQUEST
 
 
-        log.charge = machineQuery.costperminute * int(json["elapsed"]) / 60
+        log.charge = round(machineQuery.costperminute * int(json["elapsed"]) / 60, 1)
         if log.charge < machineQuery.costminimum:
             log.charge = machineQuery.costminimum
 

--- a/app/views.py
+++ b/app/views.py
@@ -156,7 +156,16 @@ def user(user_uid):
     try:
         #Pass the machine name through
         user_details = User.get(User.useruid == user_uid)
-        return render_template("user.html", user_details=user_details)
+        last_usage = Log.select(Log, Machine).join(Machine, on=(Machine.machineuid==Log.machineuid)).where(Log.useruid == user_uid).order_by(Log.starttime.desc()).limit(25)
+
+        # Calculate the time delta for the log display, and pretty-print it. Not sure this is
+        # the best way to do this, suggestions welcome.
+        for p in last_usage:
+            timediff = p.endtime - p.starttime
+            p.elapsed = format_timedelta(timediff, granularity="second", locale="en_GB")
+
+        return render_template("user.html", user_details=user_details, last_usage=last_usage)
+
     except Exception as ex:
         return "Error! %s" % str(ex)
 

--- a/app/views.py
+++ b/app/views.py
@@ -8,6 +8,7 @@ from uuid import *
 from playhouse import shortcuts
 import json
 import logging
+import datetime
 
 #Shamelessly taken from http://flask.pocoo.org/snippets/45/ - works well
 def request_wants_json():
@@ -241,5 +242,66 @@ def checkvalid(machine, card):
     else:
         return("no result!")
     '''
+'''
+LOGGING
+'''
 
-#@app.route('/induct')
+@app.route('/log/new', methods=['POST'])
+def logusage():
+    try:
+        # Force parsing as JSON even if content header is
+        # incorrect, because we don't accept anything else.
+        json = request.get_json(force=True)
+    except Exception as ex:
+        # Return a bad request if we aren't getting our JSON.
+        # This could happen if the content type isn't set properly or if the JSON
+        # is particularly malformed such that it can't even be
+        print ("Bad JSON request.")
+        print(ex)
+        return "{\"error\":\"Bad JSON\"}", 400 # 400 BAD REQUEST
+
+    try:
+        log = Log()
+        log.endtime = datetime.datetime.now()
+        log.starttime = log.endtime - datetime.timedelta(seconds=int(json["elapsed"]))
+        log.machineuid = json["machineuid"]
+
+        # Check that the machine UID exists and is associated with a machine.
+        machineQuery = Machine.select().where(Machine.machineuid == log.machineuid)
+        if machineQuery.exists() is False:
+            print ("Bad request, Machine UID doesn't exist.")
+            return "{\"error\":\"Machine UID doesn't exist\"}", 400 # 400 BAD REQUEST
+
+        # Check that the Card UID exists and is associated with a user UID. This is what
+        # we need to associate the log request with.
+        log.useruid = User.select(User.useruid).where(User.carduid == json["carduid"]).limit(1)
+        if log.useruid is None:
+            print ("Bad request, Card UID doesn't exist.")
+            return "{\"error\":\"Card UID doesn't exist\"}", 400 # 400 BAD REQUEST
+
+        # If we're debugging the App it would probably be nice to see all the json
+        # and also to save it in the database for future lookup.
+        # Otherwise store a readable note of seconds used.
+        if app.debug is True:
+            print(json)
+            log.notes = json
+        else:
+            log.notes = json["elapsed"] + "s used"
+
+    except (TypeError, ValueError) as ex:
+        print ("TypeError or ValueError when populating new log from JSON.")
+        print (json)
+        print (ex)
+        return "{\"error\":\"Bad JSON - bad value type or a value conversion error occurred.\"}", 400 # 400 BAD REQUEST
+
+    try:
+        log.save()
+    except Exception as ex:
+        # Had a problem saving the data to the database,
+        # so return an internal server error.
+        print("Error creating log in database.")
+        print(ex)
+        return "0", 500 # 500 SERVER ERROR
+
+    # Return created response
+    return "1", 201 # 201 CREATED

--- a/app/views.py
+++ b/app/views.py
@@ -129,7 +129,7 @@ def newmachine():
     elif request.method == 'POST':
         #This will be POSTed data this time, try create a new machine
         try:
-            Machine.create(creator="API", machinename=request.form['machinename'], machineuid=request.form['machineuid'], status=True)
+            Machine.create(creator="API", machinename=request.form['machinename'], machineuid=request.form['machineuid'], status=True, costperminute=request.form['costperminute'], costminimum=request.form['costminimum'])
             return render_template("newmachine.html", error=False, machine_uid=str(uuid4()))
         #Catch every exception so we can print out the error
         except Exception as ex:

--- a/app/views.py
+++ b/app/views.py
@@ -285,10 +285,15 @@ def logusage():
         log.machineuid = json["machineuid"]
 
         # Check that the machine UID exists and is associated with a machine.
-        machineQuery = Machine.select().where(Machine.machineuid == log.machineuid)
-        if machineQuery.exists() is False:
+        machineQuery = Machine.get(Machine.machineuid == log.machineuid)
+        if machineQuery is None:
             print ("Bad request, Machine UID doesn't exist.")
             return "{\"error\":\"Machine UID doesn't exist\"}", 400 # 400 BAD REQUEST
+
+
+        log.charge = machineQuery.costperminute * int(json["elapsed"]) / 60
+        if log.charge < machineQuery.costminimum:
+            log.charge = machineQuery.costminimum
 
         # Check that the Card UID exists and is associated with a user UID. This is what
         # we need to associate the log request with.

--- a/models.py
+++ b/models.py
@@ -15,6 +15,7 @@ class Log(ModelBase):
     notes = CharField(null=True)
     starttime = DateTimeField(null=True)
     useruid = CharField(null=True)
+    charge = FloatField()
 
     class Meta:
         table_name = 'log'
@@ -25,6 +26,8 @@ class Machine(ModelBase):
     machineuid = CharField(unique=True)
     machinename = CharField()
     status = IntegerField(null=True)
+    costperminute = FloatField()
+    costminimum = FloatField()
 
     class Meta:
         table_name = 'machine'

--- a/run.py
+++ b/run.py
@@ -4,4 +4,4 @@
 from app import app
 
 if __name__ == '__main__':
-    app.run(host='0.0.0.0')
+    app.run(host='0.0.0.0',threaded=True)


### PR DESCRIPTION
Adds the ability to see how much a session "costs", with the charge recorded in the log entry to allow historical look up of previous charges even if the `costperminute` or `costminimum` changes in the future. Closes leedshackspace/tool-api#7.

Machines which don't implement charging won't show anything in that column for log entries, and machines which operate on a cost-per-use basis (nothing springs to mind at the moment) can populate `costminimum` and not `costperminute`.

Requires modification to the MySQL tables as follows:
```
ALTER TABLE `lhsmachines`.`machine` 
ADD COLUMN `costperminute` FLOAT NULL DEFAULT 0.0 AFTER `id`,
ADD COLUMN `costminimum` FLOAT NULL DEFAULT 0.0 AFTER `costperminute`;

ALTER TABLE `lhsmachines`.`log` 
ADD COLUMN `charge` FLOAT NULL DEFAULT NULL AFTER `endtime`;
```

I had to cherry pick the `logging` branch commits across to this branch so I'm not sure how that will turn out once that PR is pulled in. If this is the wrong way to do this please rebase/whatever as needed.